### PR TITLE
Update to manifest version 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Gmail syntax highlighting",
   "description": "Adds a formatting button to syntax highlight code on Gmail messages.",
   "version": "1.5",
 
-  "permissions": [
+  "host_permissions": [
     "https://mail.google.com/*"
   ],
   "content_scripts": [
@@ -15,5 +15,5 @@
       "run_at": "document_end"
     }
   ],
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
Updated to latest manifest version since the old version (i.e. version2) has been deprecated and will be disallowed in 2023.